### PR TITLE
Default ZGEN_DIR to cloned location instead of ~/.zgen

### DIFF
--- a/zgenom.zsh
+++ b/zgenom.zsh
@@ -3,7 +3,11 @@
 local ZGEN_SOURCE="$0:A:h"
 
 if [[ -z "${ZGEN_DIR}" ]]; then
-    ZGEN_DIR="${HOME}/.zgen"
+    if [[ -e "${HOME}/.zgen" ]]; then
+        ZGEN_DIR="${HOME}/.zgen"
+    else
+        ZGEN_DIR="$ZGEN_SOURCE"
+    fi
 fi
 
 if [[ -z "${ZGEN_INIT}" ]]; then


### PR DESCRIPTION
When ~/.zgen exists it still defaults to ~/.zgen.

Closes https://github.com/tarjoilija/zgen/issues/86
