### PR TITLE
Fix creating compinit with custom flags

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -298,7 +298,7 @@ zgen-apply() {
         -zgpute "Initializing completions ..."
 
         autoload -Uz compinit && \
-            compinit $ZGEN_COMPINIT_FLAGS
+            eval "compinit $ZGEN_COMPINIT_FLAGS"
     fi
 }
 


### PR DESCRIPTION
Zgen save would ignore all flags and the custom directory. When
providing a custom path it would always be created as ~/.zcompdump.
Only subsequent shells would create the correct zcompdump as they
recreate it with `compinit -C ...` where the path would be correctly
inserted but the flags would be completely ignored.
