### PR TITLE
Compile files when zgen save is called

### DIFF
--- a/_zgen
+++ b/_zgen
@@ -16,6 +16,7 @@
 local -a _zgen_commands
 _zgen_commands=(
     "clone:clone plugin from repository"
+    "compile:compile files the given path"
     "completions:deprecated, please use load instead"
     "list:print init.zsh"
     "load:clone and load plugin"


### PR DESCRIPTION
It compiles *.zsh, *.sh and zcomdump*, as well as all files with zsh
shebang (`#!...zsh`).
In these paths:
- zgen source files
- plugin files
- zcompdump (if custom path or ~/.zcompdump*)

This also adds `zgen compile <path>` to the api.

Closes https://github.com/tarjoilija/zgen/issues/92
