### PR TITLE
Allow to clone without submodules

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -227,7 +227,7 @@ zgen-update() {
         -zgpute "Updating '${repo}' ..."
         (cd "${repo}" \
             && git pull \
-            && git submodule update --init --recursive)
+            && git submodule update --recursive)
     done
     zgen-reset
 }

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -125,13 +125,24 @@ fi
 
 zgen-clone() {
     local repo="${1}"
+    local submodules
+    if [[ $2 = '--no-submodules' ]]; then
+        submodules=$2
+        shift
+    else
+        submodules=$3
+    fi
     local branch="${2:-master}"
     local url="$(-zgen-get-clone-url ${repo})"
     local dir="$(-zgen-get-clone-dir ${repo} ${branch})"
 
     if [[ ! -d "${dir}" ]]; then
         mkdir -p "${dir}"
-        git clone --depth=1 --recursive -b "${branch}" "${url}" "${dir}"
+        if [[ $submodules = '--no-submodules' ]]; then
+            git clone --depth=1 -b "${branch}" "${url}" "${dir}"
+        else
+            git clone --depth=1 --recursive -b "${branch}" "${url}" "${dir}"
+        fi
     fi
 }
 


### PR DESCRIPTION
In my opinion the `load` syntax is a bit overloaded already. Also adding
other commands like `bin` would have to implement this in multiple
places.
This can however be achieved like this:

```zsh
zgen clone <repo> --no-submodules
zgen load <repo>
```

Closes https://github.com/tarjoilija/zgen/issues/129
