### PR TITLE
Make plugins/themes clone into $ZGEN_SOURCE/sources instead of $ZGEN_SOURCE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ New features:
 - Add `zgen compile` in case you want to recursively compile your dotfiles (manually).
 - Add `zgen bin` to add an executable to your `$PATH`.
 - Lazy loading zgenom by sourcing `zgenom.zsh` instead of `zgen.zsh`.
-- The default `$ZGEN_DIR` is where you cloned `zgenom` to (except when you have `~/.zgen` for backwards compatibility).
+- The default `$ZGEN_DIR` is where you cloned `zgenom` to (except when you have `~/.zgen` for backwards compatibility). Create a `~/.zgenom-separate-clones` file to have the clones created in `~/.zgenom`.
 - Allow cloning without submodules `zgen clone [repo] --no-submodules`.
 
 Bugfixes/maintenance:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ New features:
 - Add `zgen compile` in case you want to recursively compile your dotfiles (manually).
 - Add `zgen bin` to add an executable to your `$PATH`.
 - Lazy loading zgenom by sourcing `zgenom.zsh` instead of `zgen.zsh`.
-- The default `$ZGEN_DIR` is where you cloned `zgenom` to (except when you have `~/.zgen` for backwards compatibility). Create a `~/.zgenom-separate-clones` file to have the clones created in `~/.zgenom`.
+- The default `$ZGEN_DIR` is a sources subdirectory where you cloned `zgenom` to (except when you have `~/.zgen` for backwards compatibility).
 - Allow cloning without submodules `zgen clone [repo] --no-submodules`.
 
 Bugfixes/maintenance:

--- a/zgenom.zsh
+++ b/zgenom.zsh
@@ -6,11 +6,7 @@ if [[ -z "${ZGEN_DIR}" ]]; then
     if [[ -e "${HOME}/.zgen" ]]; then
         ZGEN_DIR="${HOME}/.zgen"
     else
-        if [[ -f ~/.zgenom-separate-clones ]]; then
-            ZGEN_DIR="${HOME}/.zgenom"
-        else
-            ZGEN_DIR="$ZGEN_SOURCE"
-        fi
+        ZGEN_DIR="$ZGEN_SOURCE/sources"
     fi
 fi
 

--- a/zgenom.zsh
+++ b/zgenom.zsh
@@ -6,7 +6,11 @@ if [[ -z "${ZGEN_DIR}" ]]; then
     if [[ -e "${HOME}/.zgen" ]]; then
         ZGEN_DIR="${HOME}/.zgen"
     else
-        ZGEN_DIR="$ZGEN_SOURCE"
+        if [[ -f ~/.zgenom-separate-clones ]]; then
+            ZGEN_DIR="${HOME}/.zgenom"
+        else
+            ZGEN_DIR="$ZGEN_SOURCE"
+        fi
     fi
 fi
 


### PR DESCRIPTION
By default, clone plugins and themes in a separate subdirectory tree in `$ZGEN_SOURCE` instead of at the top level.

This keeps the zgenom source directory clean and makes it easier to do a full reset of all clones by deleting `$ZGEN_SOURCE/sources`