### PR TITLE
Update autoupdate-zgen references to autoupdate-zgenom

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ zgenom.
 Zgenom provides you simple commands for managing plugins. It installs your
 plugins and generates a static init script that will source them for you every
 time you run the shell. We do this to save some startup time by not having to
-execute time consuming logic (plugin checking, updates, etc). This means that
+execute time consuming logic (plugin checking, updates, etc) every time a new shell session is started. This means that
 you have to manually check for updates (`zgenom update`) and reset the init
-script (`zgenom reset`) whenever you add or remove plugins.
+script (`zgenom reset`) whenever you add or remove plugins. If you _do_ want automatic updates, install [autoupdate-zgenom](https://github.com/unixorn/autoupdate-zgenom).
 
 ## Installation
 
@@ -396,17 +396,11 @@ Here is a partial example how to work with prezto
 
 ## Other resources
 
-The [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins) list
-contains many zgenom compatible zsh plugins & themes that you may find useful.
+The [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins) list contains many zgenom compatible zsh plugins & themes that you may find useful.
 
-There's a quickstart kit for using zsh and zgenom at
-[zsh-quickstart-kit](https://github.com/unixorn/zsh-quickstart-kit) that guides
-you through setting up zgenom and includes a sampler of useful plugins.
+There's a [zsh-quickstart-kit](https://github.com/unixorn/zsh-quickstart-kit) for using zsh and zgenom at that does a guided setup of zgenom, including installing a starting sampler of useful plugins.
 
-The [autoupdate-zgen](https://github.com/unixorn/autoupdate-zgen) plugin will
-enable your zgen to periodically update itself and your list of plugins.
-(Despite the name it should still work well with zgenom)
-
+The [autoupdate-zgenom](https://github.com/unixorn/autoupdate-zgenom) plugin enables zgenom to periodically update itself and your list of installed plugins.
 ## Alternatives
 
 - [antigen](https://github.com/zsh-users/antigen) - popular and mature


### PR DESCRIPTION
- Forked autoupdate-zgen to autoupdate-zgenom - the new plugin no longer tries to be backward compatible with zgen. Update references accordingly

- Update the zsh-quickstart-kit entry