### PR TITLE
Update readme to show proper loading of zsh-completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ EOPLUGINS
     # ^ can't indent this EOPLUGINS
 
     # completions
-    zgenom load zsh-users/zsh-completions src
+    zgenom load zsh-users/zsh-completions
 
     # theme
     zgenom ohmyzsh themes/arrow


### PR DESCRIPTION
Instead of loading the `src` folder manually zsh-completions has a plugin file which adds the correct path. When providing a folder to zgenom it will add the path to `fpath` which is the wanted behavior in this case. It also iterates over all files which match `*.sh` and will source them. Since zsh-completions has files like `_rmlint.sh` in this folder they're matched and sourced which is the not wanted behavior - resulting in an error. While this could be fixed by checking for `*.sh` and exclude `_*.sh` files I'm not sure if this is a so widely popular naming scheme that it would not break another plugin. Closes #59