### PR TITLE
Introduce automatic background updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tags
 bin
 polaris/*
 sources
+.last_autoupdate_log

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ EOPLUGINS
     zgenom compile $ZDOTDIR
 
     # You can perform other "time consuming" maintenance tasks here as well.
-    # When you are using `zgenom autoupdate --background` you're making sure
-    # they get executed every 7 days.
+    # If you use `zgenom autoupdate --background` you're making sure it gets
+    # executed every 7 days.
 
     # rbenv rehash
 fi
@@ -361,6 +361,9 @@ zgenom save
 It is recommended to save the plugin sourcing part to a static init script so
 we don't have to go through the time consuming installing/updating part every
 time we start the shell (or source .zshrc)
+
+If you don't want use a init script call `zgenom apply` after you've loaded all
+plugins. It'll take care of compinit and adding the loaded bins to your PATH.
 
 #### Remove init script
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ time you run the shell. We do this to save some startup time by not having to
 execute time consuming logic (plugin checking, updates, etc) every time a new
 shell session is started. This means that you have to manually check for
 updates (`zgenom update`) and reset the init script (`zgenom reset`) whenever
-you add or remove plugins. If you _do_ want automatic updates, see
-[autoupdate](#Run-updates-automatically).
+you add or remove plugins.
+
+Zgenom does have a `zgenom autoupdate --background` which checks for updates
+periodically without startup penalty or having to wait for the plugins to
+update. See [here](#Run-updates-automatically) for more information.
 
 ## Installation
 
@@ -86,8 +89,9 @@ and `oh-my-zsh` can be used interchangeably.
 # load zgenom
 source "${HOME}/.zgenom/zgenom.zsh"
 
-# Uncomment to check for plugin and zgenom updates every 7 days
-# zgenom autoupdate
+# Check for plugin and zgenom updates every 7 days
+# This does not reduce the startup time.
+zgenom autoupdate --background
 
 # if the init script doesn't exist
 if ! zgenom saved; then
@@ -141,6 +145,8 @@ EOPLUGINS
     zgenom compile $ZDOTDIR
 
     # You can perform other "time consuming" maintenance tasks here as well.
+    # When you are using `zgenom autoupdate --background` you're making sure
+    # they get executed every 7 days.
 
     # rbenv rehash
 fi
@@ -187,7 +193,8 @@ probably a better idea to always load the plugin instead.
 - Update to `ohmyzsh/ohmyzsh`.
 - Implement the [Zsh Plugin Standard](#Zsh-Plugin-Standard).
 - Add `zgenom clean` to remove all unused plugins.
-- Add `zgenom autoupdate` to check for updates periodically.
+- Add `zgenom autoupdate` to check for updates periodically and optionally
+  dispatch it to the background to remove any waiting times.
 
 ## Usage
 
@@ -395,6 +402,8 @@ zgenom selfupdate
 #### Run updates automatically
 
 ```zsh
+source path/to/zgenom.zsh
+
 # Update every 7 days
 zgenom autoupdate
 
@@ -409,6 +418,9 @@ zgenom autoupdate --plugin 7
 
 # Update plugins every 7 days and zgenom every 14 days
 zgenom autoupdate --plugin 7 --self 14
+
+if ! zgenom saved; then
+    # load plugins
 ```
 
 Call `zgenom selfupdate` and `zgenom update` regularly. If you call one of them
@@ -417,9 +429,34 @@ update every x days.
 
 Make sure to call it before you check for the init file with `zgenom saved`.
 
-**Note:** Using `zgenom autoupdate` increases the startup time around 30% (~30ms).
-This figure may vary depending on your plugins and machine.
-I'll try to decrease startup penalty in the future.
+**Note**: Using `zgenom autoupdate` increases the startup time around 30%
+(~30ms) in order to check if an update has to be done. This figure may vary
+depending on your plugins and machine. Use `--background` to remove the waiting
+time.
+
+#### Run updates automatically in the background
+
+```zsh
+source path/to/zgenom.zsh
+
+# Just append `--background` to the `zgenom autoupdate` call.
+# E.g.: Update every 7 days without ever having to wait for plugins to be updated.
+zgenom autoupdate --background
+
+if ! zgenom saved; then
+    # load plugins
+```
+
+These backups will run fully in the background so you won't any slowdown
+in your startup time. When the update is complete and you start a new
+shell everything is prepared so you don't have to wait then either. When
+starting a new shell after a completed update you will get a log showing you
+what happened in the background.
+
+**Note:** If your .zshrc contains any interactive prompts you might encounter
+issues with some terminals. In my tests `neovim`s builtin terminal emulator
+wouldn't render the message but would wait for the input (and behave
+correctly).
 
 #### Clean zgenom plugins
 

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ update every x days.
 
 Make sure to call it before you check for the init file with `zgenom saved`.
 
-**Note**: Using `zgenom autoupdate` increases the startup time around 30%
+**Note:** Using `zgenom autoupdate` increases the startup time around 30%
 (~30ms) in order to check if an update has to be done. This figure may vary
 depending on your plugins and machine. Use `--background` to remove the waiting
 time.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ and `oh-my-zsh` can be used interchangeably.
 source "${HOME}/.zgenom/zgenom.zsh"
 
 # Check for plugin and zgenom updates every 7 days
-# This does not reduce the startup time.
+# This does not increase the startup time.
 zgenom autoupdate --background
 
 # if the init script doesn't exist

--- a/functions/__zgenom_autoupdate
+++ b/functions/__zgenom_autoupdate
@@ -1,0 +1,86 @@
+#!/usr/bin/env zsh
+
+function __zgenom_check_interval() {
+    local last_update
+    if [[ ! -f $1 ]]; then
+        # We've never run, set the last run time to the dawn of time, or at
+        # least the dawn of posix time.
+        last_update=0
+        printf 0 > $1
+    else
+        read -r last_update < $1
+    fi
+    expr $2 - $last_update
+}
+
+function __zgenom_should_autoupdate() {
+    local min_interval=$(( $1 * 86400 )) # days to seconds
+    local last_update=$(__zgenom_check_interval "$ZGEN_DIR/.zgenom-$2-lastupdate" $3)
+
+    if [[ $last_update -gt $min_interval ]]; then
+        if [[ -n "$4" ]]; then
+            local days=$(( $last_update / 86400 ))
+            if [[ $days -le 18840 ]]; then
+                __zgenom_out "It has been $days days since your last $2 update."
+            else
+                __zgenom_out "Never automatically updated '$2'."
+            fi
+        fi
+        return 0
+    fi
+    return 1
+}
+
+# Don't update if we're running as different user than whoever
+# owns ZGEN_DIR. This prevents sudo runs from leaving root-owned
+# files & directories in ZGEN_DIR that will break future update
+# runs by the user.
+#
+# Using ls and awk instead of stat because stat has incompatible arguments
+# on linux, macOS and FreeBSD.
+function __zgenom_autoupdate() {
+    # NOTE: This could be sped up by moving the background check before the
+    #       parameter checking.
+    #       This only reduces the startup time by ~1ms and
+    #       would result in errors not shown in the executing shell but in the
+    #       backgrounded shell.
+    #       That's why I decided not to keep it this way.
+    local zgen_owner=$(command ls -ld $ZGEN_DIR | awk '{print $3}')
+    local updated=0
+
+    if [[ "$zgen_owner" == "$USER" ]]; then
+        zmodload zsh/system
+        local lockfile="$HOME/.zgenom-autoupdate-lock"
+        printf '' > "$lockfile"
+        if ! which zsystem &> /dev/null || zsystem flock -t 1 "$lockfile"; then
+            local now=$(command date '+%s')
+
+            # Update self
+            if [[ -n $self ]] && __zgenom_should_autoupdate $self system $now $verbose; then
+                [[ -n $verbose ]] && __zgenom_err "Updating zgenom ..."
+                zgenom selfupdate --no-reset && __zgenom_out
+                updated=1
+            fi
+
+            # Update plugins
+            if [[ -n $plugin ]] && __zgenom_should_autoupdate $plugin plugin $now $verbose; then
+                [[ -n $verbose ]] && __zgenom_err "Updating plugins ..."
+                zgenom update --no-reset
+                updated=1
+            fi
+
+            [[ $updated -ge 1 ]] && zgenom reset && __zgenom_out
+
+            command rm -f "$lockfile"
+        fi
+    else
+        if [[ -n "$DEBUG" ]]; then
+            __zgenom_out "Skipping autoupdate of plugins because $USER doesn't own $ZGEN_DIR."
+        fi
+    fi
+
+    # Return true if updated
+    [[ $updated -ge 1 ]]
+}
+
+__zgenom_autoupdate $@

--- a/functions/__zgenom_autoupdate
+++ b/functions/__zgenom_autoupdate
@@ -39,12 +39,6 @@ function __zgenom_should_autoupdate() {
 # Using ls and awk instead of stat because stat has incompatible arguments
 # on linux, macOS and FreeBSD.
 function __zgenom_autoupdate() {
-    # NOTE: This could be sped up by moving the background check before the
-    #       parameter checking.
-    #       This only reduces the startup time by ~1ms and
-    #       would result in errors not shown in the executing shell but in the
-    #       backgrounded shell.
-    #       That's why I decided not to keep it this way.
     local zgen_owner=$(command ls -ld $ZGEN_DIR | awk '{print $3}')
     local updated=0
 

--- a/functions/zgenom-autoupdate
+++ b/functions/zgenom-autoupdate
@@ -77,7 +77,7 @@ function zgenom-autoupdate() {
             ) &!
         }
 
-        # Store state
+        # Save state
         _ZGENOM_SELF=$self
         _ZGENOM_PLUGIN=$plugin
         _ZGENOM_VERBOSE=$verbose

--- a/functions/zgenom-autoupdate
+++ b/functions/zgenom-autoupdate
@@ -64,11 +64,14 @@ function zgenom-autoupdate() {
 
             # Dispatch update in the background
             (
+                # Some plugins (e.g. romkatv/gitstatus) may raise issues with
+                # `zsh -il -c exit` since it isn't really an interactive shell.
+                # Hence a non interactive shell sourcing .zshrc is used.
+                local cmd="source ${${${(q)${ZDOTDIR:-~}}/#${(q)home}/'~'}//\%/%%}/.zshrc"
                 local log=$(
-                    local zshrc=${${${(q)${ZDOTDIR:-~}}/#${(q)home}/'~'}//\%/%%}/.zshrc
                     __zgenom_autoupdate 2>&1 \
                         && printf 'Recreating init.zsh\n\n' \
-                        && _ZGENOM_JUST_INIT=1 zsh -c "source $zshrc" 2>&1
+                        && _ZGENOM_JUST_INIT=1 zsh -c $cmd 2>&1
                 )
                 [[ -n $log ]] && printf '%s\n\n' $log > "$ZGEN_SOURCE/.last_autoupdate_log"
             ) &!

--- a/functions/zgenom-autoupdate
+++ b/functions/zgenom-autoupdate
@@ -29,7 +29,7 @@ function zgenom-autoupdate() {
     #       backgrounded shell.
     #       That's why I decided not to keep it this way.
     local self plugin verbose background
-    zparseopts -D -E -self:=self -plugin:=plugin -verbose=verbose v=verbose -background=background
+    zparseopts -D -E -self:=self -plugin:=plugin -verbose=verbose v=verbose -background=background || return
 
     if [[ -z $self ]] && [[ -z $plugin ]]; then
         if [[ -n $1 && $1 -lt 1 ]]; then
@@ -55,7 +55,7 @@ function zgenom-autoupdate() {
 
             # Updating kills the migration process in some terminals...
             # E.g. neovims builtin terminal emulator.
-            [[ -z $_ZGENOM_NEEDS_MIGRATION ]] || return
+            [[ -z $_ZGENOM_NEEDS_MIGRATION ]] || return 0
 
             # Retrieve state
             local self=$_ZGENOM_SELF && unset _ZGENOM_SELF

--- a/functions/zgenom-autoupdate
+++ b/functions/zgenom-autoupdate
@@ -1,83 +1,89 @@
 #!/usr/bin/env zsh
 
-__zgenom-check-interval() {
-    local last_update
-    if [[ ! -f $1 ]]; then
-        # We've never run, set the last run time to the dawn of time, or at
-        # least the dawn of posix time.
-        last_update=0
-        echo 0 > $1
-    else
-        read -r last_update < $1
-    fi
-    expr $2 - $last_update
-}
+# Prevent recursion when starting a shell in the background
+[[ -z $_ZGENOM_JUST_INIT ]] || return
 
-__zgenom-should-autoupdate() {
-    local min_interval=$(( $1 * 86400 )) # days to seconds
-    local last_update=$(__zgenom-check-interval "$ZGEN_DIR/.zgenom-$2-lastupdate" $3)
+# Show last log if it exists
+if [[ -s "$ZGEN_SOURCE/.last_autoupdate_log" ]]; then
+    function __zgenom_autoupdate_log() {
+        add-zsh-hook -d precmd __zgenom_autoupdate_log
+        unfunction __zgenom_autoupdate_log
 
-    if [[ $last_update -gt $min_interval ]]; then
-        if [[ -n "$4" ]]; then
-            echo "It has been $(( $last_update / 86400 )) days since your last $2 update."
-        fi
-        return 0
-    fi
-    return 1
-}
+        printf '\n%s\n--------\n' 'Last zgenom autoupdate log:'
+        printf '%s\n' "${(@f)$(<$ZGEN_SOURCE/.last_autoupdate_log)}"
+        printf '--------\n'
+        printf '' > "$ZGEN_SOURCE/.last_autoupdate_log"
+    }
 
-# Don't update if we're running as different user than whoever
-# owns ZGEN_DIR. This prevents sudo runs from leaving root-owned
-# files & directories in ZGEN_DIR that will break future update
-# runs by the user.
-#
-# Using ls and awk instead of stat because stat has incompatible arguments
-# on linux, macOS and FreeBSD.
+    # A precmd hook is needed since some terminals swallow output of shell startup.
+    autoload -Uz add-zsh-hook
+    add-zsh-hook precmd __zgenom_autoupdate_log
+fi
+
+autoload -Uz __zgenom_autoupdate
 function zgenom-autoupdate() {
-    local self plugin verbose
-    zparseopts -D -E -self:=self -plugin:=plugin -verbose=verbose v=verbose
+    # NOTE: This could be sped up by moving the background check before the
+    #       parameter checking.
+    #       This only reduces the startup time by ~1ms and
+    #       would result in errors not shown in the executing shell but in the
+    #       backgrounded shell.
+    #       That's why I decided not to keep it this way.
+    local self plugin verbose background
+    zparseopts -D -E -self:=self -plugin:=plugin -verbose=verbose v=verbose -background=background
 
     if [[ -z $self ]] && [[ -z $plugin ]]; then
+        if [[ -n $1 && $1 -lt 1 ]]; then
+            __zgenom_err "You must specify an integer number of days, greater than zero."
+            return 1
+        fi
         self=${1:-7}
-        plugin=${1:-7}
+        plugin=$self
     else
         [[ -n $self ]] && self=$self[2]
         [[ -n $plugin ]] && plugin=$plugin[2]
+        if [[ -n $self && $self -lt 1 ]] || [[ -n $plugin && $plugin -lt 1 ]]; then
+            __zgenom_err "You must specify an integer number of days, greater than zero."
+            return 1
+        fi
     fi
     verbose=${verbose:-$ZGENOM_AUTOUPDATE_VERBOSE}
 
-    if [[ -n $self && $self -lt 1 ]] || [[ -n $plugin && $plugin -lt 1 ]]; then
-        echo "You must specify an integer number of days, greater than zero."
-        return 1
-    fi
+    if [[ -n  $background ]]; then
+        function __zgenom_autoupdate_background() {
+            add-zsh-hook -d precmd __zgenom_autoupdate_background
+            unfunction __zgenom_autoupdate_background
 
-    local zgen_owner=$(ls -ld $ZGEN_DIR | awk '{print $3}')
+            # Updating kills the migration process in some terminals...
+            # E.g. neovims builtin terminal emulator.
+            [[ -z $_ZGENOM_NEEDS_MIGRATION ]] || return
 
-    if [[ "$zgen_owner" == "$USER" ]]; then
-        zmodload zsh/system
-        local lockfile="$HOME/.zgenom-autoupdate-lock"
-        printf '' > "$lockfile"
-        if ! which zsystem &> /dev/null || zsystem flock -t 1 "$lockfile"; then
-            local now=$(command date '+%s')
+            # Retrieve state
+            local self=$_ZGENOM_SELF && unset _ZGENOM_SELF
+            local plugin=$_ZGENOM_PLUGIN && unset _ZGENOM_PLUGIN
+            local verbose=$_ZGENOM_VERBOSE && unset _ZGENOM_VERBOSE
 
-            # Update self
-            if [[ -n $self ]] && __zgenom-should-autoupdate $self system $now $verbose; then
-                [[ -n $verbose ]] && echo "Updating zgenom..."
-                zgenom selfupdate
-            fi
+            # Dispatch update in the background
+            (
+                local log=$(
+                    local zshrc=${${${(q)${ZDOTDIR:-~}}/#${(q)home}/'~'}//\%/%%}/.zshrc
+                    __zgenom_autoupdate 2>&1 \
+                        && printf 'Recreating init.zsh\n\n' \
+                        && _ZGENOM_JUST_INIT=1 zsh -c "source $zshrc" 2>&1
+                )
+                [[ -n $log ]] && printf '%s\n\n' $log > "$ZGEN_SOURCE/.last_autoupdate_log"
+            ) &!
+        }
 
-            # Update plugins
-            if [[ -n $plugin ]] && __zgenom-should-autoupdate $plugin plugin $now $verbose; then
-                [[ -n $verbose ]] && echo "Updating plugins..."
-                zgenom update
-            fi
+        # Store state
+        _ZGENOM_SELF=$self
+        _ZGENOM_PLUGIN=$plugin
+        _ZGENOM_VERBOSE=$verbose
 
-            command rm -f "$lockfile"
-        fi
+        # Schedule update right before the first prompt is drawn.
+        autoload -Uz add-zsh-hook
+        add-zsh-hook precmd __zgenom_autoupdate_background
     else
-        if [[ -n "$DEBUG" ]]; then
-            echo "Skipping autoupdate of plugins because $USER doesn't own $ZGEN_DIR."
-        fi
+        __zgenom_autoupdate
     fi
 }
 

--- a/functions/zgenom-selfupdate
+++ b/functions/zgenom-selfupdate
@@ -2,10 +2,17 @@
 
 function zgenom-selfupdate() {
     if [[ -e "${ZGEN_SOURCE}/.git" ]]; then
-        (cd "${ZGEN_SOURCE}" \
-            && git pull) \
-            && zgenom-reset \
-            && date +%s >! "$ZGEN_DIR/.zgenom-system-lastupdate"
+        local no_reset
+        zparseopts -D -E -no-reset=no_reset
+        pushd -q "${ZGEN_SOURCE}"
+        if git pull; then
+            if [[ -z $no_reset ]]; then
+                __zgenom_out
+                zgen-reset
+            fi
+            date +%s >! "$ZGEN_DIR/.zgenom-system-lastupdate"
+        fi
+        popd -q
     else
         __zgenom_err "Not running from a git repository; cannot automatically update."
         return 1

--- a/functions/zgenom-selfupdate
+++ b/functions/zgenom-selfupdate
@@ -8,7 +8,7 @@ function zgenom-selfupdate() {
         if git pull; then
             if [[ -z $no_reset ]]; then
                 __zgenom_out
-                zgen-reset
+                zgenom-reset
             fi
             date +%s >! "$ZGEN_DIR/.zgenom-system-lastupdate"
         fi

--- a/functions/zgenom-update
+++ b/functions/zgenom-update
@@ -64,7 +64,7 @@ function zgenom-update() {
         __zgenom_out ''
     done
 
-    [[ -z $no_reset ]] && zgen-reset
+    [[ -z $no_reset ]] && zgenom-reset
     date +%s >! "$ZGEN_DIR/.zgenom-plugin-lastupdate"
 }
 

--- a/functions/zgenom-update
+++ b/functions/zgenom-update
@@ -52,6 +52,8 @@ function __zgenom_git_pull() {
 }
 
 function zgenom-update() {
+    local no_reset
+    zparseopts -D -E -no-reset=no_reset
     setopt localoptions extended_glob nullglob
     for repo in $ZGEN_DIR/**/*/.git/; do
         repo="${repo%/.git/}"
@@ -62,7 +64,7 @@ function zgenom-update() {
         __zgenom_out ''
     done
 
-    zgenom-reset
+    [[ -z $no_reset ]] && zgen-reset
     date +%s >! "$ZGEN_DIR/.zgenom-plugin-lastupdate"
 }
 


### PR DESCRIPTION
These backups will run fully in the background so you won't any slowdown in your startup time.
When the update is complete and you start a new shell everything is prepared so you don't have to wait then either.
When starting a new shell after a completed update you will get a log showing you what happened in the background.