### PR TITLE
Improve performance of autoupdate checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,8 +432,8 @@ update every x days.
 
 Make sure to call it before you check for the init file with `zgenom saved`.
 
-**Note:** Using `zgenom autoupdate` increases the startup time around 30%
-(~30ms) in order to check if an update has to be done. This figure may vary
+**Note:** Using `zgenom autoupdate` increases the startup time around 24%
+(~23ms) in order to check if an update has to be done. This figure may vary
 depending on your plugins and machine. Use `--background` to remove the waiting
 time.
 

--- a/README.md
+++ b/README.md
@@ -432,8 +432,8 @@ update every x days.
 
 Make sure to call it before you check for the init file with `zgenom saved`.
 
-**Note:** Using `zgenom autoupdate` increases the startup time around 24%
-(~23ms) in order to check if an update has to be done. This figure may vary
+**Note:** Using `zgenom autoupdate` increases the startup time around 17%
+(~16ms) in order to check if an update has to be done. This figure may vary
 depending on your plugins and machine. Use `--background` to remove the waiting
 time.
 

--- a/functions/__zgenom_autoupdate
+++ b/functions/__zgenom_autoupdate
@@ -1,27 +1,22 @@
 #!/usr/bin/env zsh
 
-function __zgenom_check_interval() {
+function __zgenom_should_autoupdate() {
+    local days=$1
+    local file="$ZGEN_DIR/.zgenom-$2-lastupdate"
     local last_update
-    if [[ ! -f $1 ]]; then
+    if [[ ! -f $file ]]; then
         # We've never run, set the last run time to the dawn of time, or at
         # least the dawn of posix time.
-        last_update=0
-        printf 0 > $1
+        printf 0 > $file
+        last_update=$now
     else
-        read -r last_update < $1
+        last_update=$(( $now - $(< $file) - $days * 86400 ))
     fi
-    expr $2 - $last_update
-}
 
-function __zgenom_should_autoupdate() {
-    local min_interval=$(( $1 * 86400 )) # days to seconds
-    local last_update=$(__zgenom_check_interval "$ZGEN_DIR/.zgenom-$2-lastupdate" $3)
-
-    if [[ $last_update -gt $min_interval ]]; then
-        if [[ -n "$4" ]]; then
-            local days=$(( $last_update / 86400 ))
-            if [[ $days -le 18840 ]]; then
-                __zgenom_out "It has been $days days since your last $2 update."
+    if [[ $last_update -ge 0 ]]; then
+        if [[ -n $verbose ]]; then
+            if [[ $last_update -ne $now ]]; then
+                __zgenom_out "It has been $(( $last_update / 86400 + $days)) days since your last $2 update."
             else
                 __zgenom_out "Never automatically updated '$2'."
             fi
@@ -39,10 +34,10 @@ function __zgenom_should_autoupdate() {
 # Using ls and awk instead of stat because stat has incompatible arguments
 # on linux, macOS and FreeBSD.
 function __zgenom_autoupdate() {
-    local zgen_owner=$(command ls -ld $ZGEN_DIR | awk '{print $3}')
+    local zgenom_owner=$(command ls -ld $ZGEN_DIR | awk '{print $3}')
     local updated=0
 
-    if [[ "$zgen_owner" == "$USER" ]]; then
+    if [[ "$zgenom_owner" == "$USER" ]]; then
         zmodload zsh/system
         local lockfile="$HOME/.zgenom-autoupdate-lock"
         printf '' > "$lockfile"
@@ -50,17 +45,15 @@ function __zgenom_autoupdate() {
             local now=$(command date '+%s')
 
             # Update self
-            if [[ -n $self ]] && __zgenom_should_autoupdate $self system $now $verbose; then
+            if [[ -n $self ]] && __zgenom_should_autoupdate $self system; then
                 [[ -n $verbose ]] && __zgenom_err "Updating zgenom ..."
-                zgenom selfupdate --no-reset && __zgenom_out
-                updated=1
+                zgenom selfupdate --no-reset && __zgenom_out && updated=1
             fi
 
             # Update plugins
-            if [[ -n $plugin ]] && __zgenom_should_autoupdate $plugin plugin $now $verbose; then
+            if [[ -n $plugin ]] && __zgenom_should_autoupdate $plugin plugin; then
                 [[ -n $verbose ]] && __zgenom_err "Updating plugins ..."
-                zgenom update --no-reset
-                updated=1
+                zgenom update --no-reset && updated=1
             fi
 
             [[ $updated -ge 1 ]] && zgenom reset && __zgenom_out

--- a/functions/__zgenom_autoupdate
+++ b/functions/__zgenom_autoupdate
@@ -44,8 +44,8 @@ function __zgenom_autoupdate() {
     if [[ "$zgenom_owner" == "$USER" ]]; then
         local lockfile="$HOME/.zgenom-autoupdate-lock"
         printf '' > "$lockfile"
-        # Create lock
-        if zsystem flock -t 1 "$lockfile"; then
+        # Create lock, don't retry to obtain a lock
+        if zsystem flock -t 0 "$lockfile" &>/dev/null; then
             local now=$(command date '+%s')
 
             # Update self
@@ -62,6 +62,9 @@ function __zgenom_autoupdate() {
 
             # Reset only when updated
             [[ $updated -ge 1 ]] && zgenom reset && __zgenom_out
+
+            # Release the lock
+            printf '' > "$lockfile"
 
             # Remove lock file
             command rm -f "$lockfile"

--- a/functions/__zgenom_autoupdate
+++ b/functions/__zgenom_autoupdate
@@ -12,8 +12,7 @@ function __zgenom_should_autoupdate() {
     local file="$ZGEN_DIR/.zgenom-$2-lastupdate"
     local last_update
     if [[ ! -f $file ]]; then
-        # We've never run, set the last run time to the dawn of time, or at
-        # least the dawn of posix time.
+        # We've never run, create the lastupdate-file and set now as interval.
         printf 0 > $file
         last_update=$now
     else
@@ -22,10 +21,10 @@ function __zgenom_should_autoupdate() {
 
     if [[ $last_update -ge 0 ]]; then
         if [[ -n $verbose ]]; then
-            if [[ $last_update -ne $now ]]; then
-                __zgenom_out "It has been $(( $last_update / 86400 + $days)) days since your last $2 update."
-            else
+            if [[ $last_update -eq $now ]]; then
                 __zgenom_out "Never automatically updated '$2'."
+            else
+                __zgenom_out "It has been $(( $last_update / 86400 + $days)) days since your last $2 update."
             fi
         fi
         return 0
@@ -33,20 +32,20 @@ function __zgenom_should_autoupdate() {
     return 1
 }
 
-# Don't update if we're running as different user than whoever
-# owns ZGEN_DIR. This prevents sudo runs from leaving root-owned
-# files & directories in ZGEN_DIR that will break future update
-# runs by the user.
-#
-# Using ls and awk instead of stat because stat has incompatible arguments
-# on linux, macOS and FreeBSD.
 function __zgenom_autoupdate() {
+    # Using ls and awk instead of stat because stat has incompatible arguments
+    # on linux, macOS and FreeBSD.
     local zgenom_owner=$(command ls -ld $ZGEN_DIR | awk '{print $3}')
     local updated=0
 
+    # Don't update if we're running as different user than whoever
+    # owns ZGEN_DIR. This prevents sudo runs from leaving root-owned
+    # files & directories in ZGEN_DIR that will break future update
+    # runs by the user.
     if [[ "$zgenom_owner" == "$USER" ]]; then
         local lockfile="$HOME/.zgenom-autoupdate-lock"
         printf '' > "$lockfile"
+        # Create lock
         if zsystem flock -t 1 "$lockfile"; then
             local now=$(command date '+%s')
 
@@ -62,8 +61,10 @@ function __zgenom_autoupdate() {
                 zgenom update --no-reset && updated=1
             fi
 
+            # Reset only when updated
             [[ $updated -ge 1 ]] && zgenom reset && __zgenom_out
 
+            # Remove lock file
             command rm -f "$lockfile"
         fi
     else

--- a/functions/__zgenom_autoupdate
+++ b/functions/__zgenom_autoupdate
@@ -1,5 +1,8 @@
 #!/usr/bin/env zsh
 
+# Bail out when zsh/system is not available
+zmodload zsh/system || return 0 # Return 0 since 0 is no update
+
 function __zgenom_should_autoupdate() {
     local days=$1
     local file="$ZGEN_DIR/.zgenom-$2-lastupdate"
@@ -38,10 +41,9 @@ function __zgenom_autoupdate() {
     local updated=0
 
     if [[ "$zgenom_owner" == "$USER" ]]; then
-        zmodload zsh/system
         local lockfile="$HOME/.zgenom-autoupdate-lock"
         printf '' > "$lockfile"
-        if ! which zsystem &> /dev/null || zsystem flock -t 1 "$lockfile"; then
+        if zsystem flock -t 1 "$lockfile"; then
             local now=$(command date '+%s')
 
             # Update self

--- a/functions/__zgenom_autoupdate
+++ b/functions/__zgenom_autoupdate
@@ -3,8 +3,7 @@
 # Bail out when zsh/system is not available
 zmodload zsh/system || {
     __zgenom_err 'Could not load `zsh/system` which is needed for autoupdate. Please create an issue.'
-     # Return 0 since 0 is no update
-    return 0
+    return 1
 }
 
 function __zgenom_should_autoupdate() {

--- a/functions/__zgenom_autoupdate
+++ b/functions/__zgenom_autoupdate
@@ -1,7 +1,11 @@
 #!/usr/bin/env zsh
 
 # Bail out when zsh/system is not available
-zmodload zsh/system || return 0 # Return 0 since 0 is no update
+zmodload zsh/system || {
+    __zgenom_err 'Could not load `zsh/system` which is needed for autoupdate. Please create an issue.'
+     # Return 0 since 0 is no update
+    return 0
+}
 
 function __zgenom_should_autoupdate() {
     local days=$1

--- a/functions/__zgenom_autoupdate
+++ b/functions/__zgenom_autoupdate
@@ -67,7 +67,7 @@ function __zgenom_autoupdate() {
             printf '' > "$lockfile"
 
             # Remove lock file
-            command rm -f "$lockfile"
+            { command rm -f "$lockfile" } &!
         fi
     else
         if [[ -n "$DEBUG" ]]; then

--- a/functions/zgenom-autoupdate
+++ b/functions/zgenom-autoupdate
@@ -86,7 +86,8 @@ function zgenom-autoupdate() {
         autoload -Uz add-zsh-hook
         add-zsh-hook precmd __zgenom_autoupdate_background
     else
-        __zgenom_autoupdate
+        # Don't propagate error if not updated
+        __zgenom_autoupdate || true
     fi
 }
 


### PR DESCRIPTION
This reduced the startup time of autoupdate without `--background`
around ~~7ms~~ 14ms for me.
Now the main culprit is checking whether the current user is the
zgenom_owner ~~and if a update is currently running (in another shell)~~.
