### PR TITLE
Removed extra underscore causing error message

### DIFF
--- a/functions/zgenom-ohmyzsh
+++ b/functions/zgenom-ohmyzsh
@@ -2,7 +2,7 @@
 
 function zgenom-oh-my-zsh() {
     if [[ -z $ZSH ]]; then
-        ZSH="$(___zgenom_clone_dir "$ZGEN_OH_MY_ZSH_REPO" "$ZGEN_OH_MY_ZSH_BRANCH")"
+        ZSH="$(__zgenom_clone_dir "$ZGEN_OH_MY_ZSH_REPO" "$ZGEN_OH_MY_ZSH_BRANCH")"
     fi
 
     local file="${1:-oh-my-zsh.sh}"


### PR DESCRIPTION
Regenerating the init file was causing an error message due to there being an extra underscore in "__zgenom_clone_dir" so I removed the underscore and it's been fixed