### PR TITLE
Allow extensions to integrate into zgenom

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,15 @@ zsh file it can recursively find in `~/.zsh`. You might not want to add any of
 these lines to your `.zsrhc` but run them manually or automatically in the
 background.
 
+#### Safely access internal api
+
+Calling any function matching `__zgenom-*` is assumed unsafe and the function
+is considered private. So it may be renamed anytime without further notice.
+
+To provide a way to safely access some internal api `zgenom api` is introduced.
+Please use the zsh completion to check what parts of the internal api is
+exposed.
+
 </details>
 
 ## Notes
@@ -510,6 +519,30 @@ be disabled if you've already called `compinit` yourself before sourcing
 `$ZGEN_AUTOLOAD_COMPINIT`.
 
   [compinit]: <http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Use-of-compinit> "Zsh manual 20.2.1: Use of compinit"
+
+## Extensions
+
+Extensions may be a bit of a stretch. Every function matching `zgenom-*` is
+callable like `zgenom *`. Every completion function matching `_zgenom_*` is
+called by `_zgenom`.
+
+Also `$ZGENOM_EXTENSIONS` can be used to add an entry to `zgenom help` and
+subcommand completion.
+
+To provide an extension called `abc` you define `zgenom-abc` in your plugin.
+Then you can add a description: `ZGENOM_EXTENSIONS+=('abc:Some description')`.
+To provide additional completions you can define `_zgenom_abc` which will be
+called when the prompt starts with `zgenom abc`.
+
+Existing extensions:
+
+- [release](https://github.com/jandamm/zgenom-ext-release): Use `zgenom` and
+  `gh` to download github releases.
+
+Please create a PR to add your extension here :)
+
+**Note:** It is not recommended to use the private api (`__zgenom-*`) since it
+may change without further notice. Use `zgenom api` instead.
 
 ## Other resources
 

--- a/commands.txt
+++ b/commands.txt
@@ -1,3 +1,4 @@
+api:^^^^^^^^^^^use parts of the internal api with a stable api
 apply:^^^^^^^^^apply setup to current shell (only use if you don't use 'save')
 autoupdate:^^^^automatically check for updates of zgenom and plugins
 bin:^^^^^^^^^^^clone and add files to PATH

--- a/functions/_zgenom
+++ b/functions/_zgenom
@@ -1,5 +1,27 @@
 #compdef zgenom
 
+function _zgenom_api() {
+    _arguments '2: :->cmd' '*: :->opts'
+    case $state in
+        cmd)
+            local commands=(
+                'clone_dir[get directory where the repository is cloned to]'
+                'err[error method of zgenom]'
+                'out[output method of zgenom]'
+            )
+            _values -w commands $commands ;;
+        opts)
+            if [[ $words[3] = 'clone_dir' ]]; then
+                local options=(
+                    '--branch[define which branch to use (default: follow head)]'
+                    '--legacy[use the zgen naming pattern]'
+                )
+                _values -w options $options
+            fi
+            ;;
+    esac
+}
+
 function _zgenom_autoupdate() {
     local days=(1 2 3 5 7 14)
     if [[ $words[-2] = '--plugin' || $words[-2] = '--self' ]]; then

--- a/functions/_zgenom
+++ b/functions/_zgenom
@@ -31,16 +31,18 @@ function _zgenom() {
     case $state in
         cmd)
             local -a commands
+            commands=$ZGENOM_EXTENSIONS
             for line in "${(@f)$(< $ZGEN_SOURCE/commands.txt)}"; do
                 commands+=( "${line//\^/}" )
             done
             _describe -t commands 'command' commands "$@"
             ;;
         opts)
-            case $words[2] in
-                autoupdate) _zgenom_autoupdate;;
+            local subcmd=$words[2]
+            case $subcmd in
                 compile) _files;;
                 selfupdate|update) _values -w options "--no-reset[don't remove init.zsh after updating]";;
+                *) functions _zgenom_$subcmd &> /dev/null && _zgenom_$subcmd "$@";;
             esac
             ;;
     esac

--- a/functions/zgenom-api
+++ b/functions/zgenom-api
@@ -1,0 +1,19 @@
+#!/usr/bin/env zsh
+
+# This command provides a safe way to call parts of the internal api. In
+# general it is not recommended to manually call __zgenom_* functions since
+# they may not be loaded or some state may not be set.
+# Calling `zgenom api clone_dir` ensures a state where it is safe to call the
+# underlying function.
+function zgenom-api() {
+	[[ $# -eq 0 ]] && __zgenom_err 'No subcommand provided.' && return 1
+	local subcmd=$1; shift
+	case $subcmd in
+		clone_dir) __zgenom_clone_dir $@;;
+		err) __zgenom_err $@;;
+		out) __zgenom_out $@;;
+		*) __zgenom_err "Unknown api command: $subcmd." && return 1;;
+	esac
+}
+
+zgenom-api $@

--- a/functions/zgenom-help
+++ b/functions/zgenom-help
@@ -9,7 +9,8 @@ function zgenom-help() {
     __zgenom_out "    Please check the zsh completion to find out more about the options of commands."
     if [[ -n $ZGENOM_EXTENSIONS[1] ]]; then
         __zgenom_out
-        __zgenom_out '    commands provided by extensions:'
+        __zgenom_out 'installed extensions'
+        __zgenom_out '    commands:'
         __zgenom_out
         for cmd in $ZGENOM_EXTENSIONS; do
             printf   '    %s\n' ${cmd/:/: }

--- a/functions/zgenom-help
+++ b/functions/zgenom-help
@@ -7,6 +7,14 @@ function zgenom-help() {
     printf       '    %s\n' ${"${(@f)$(< $ZGEN_SOURCE/commands.txt)}"//\^/ }
     __zgenom_out
     __zgenom_out "    Please check the zsh completion to find out more about the options of commands."
+    if [[ -n $ZGENOM_EXTENSIONS[1] ]]; then
+        __zgenom_out
+        __zgenom_out '    commands provided by extensions:'
+        __zgenom_out
+        for cmd in $ZGENOM_EXTENSIONS; do
+            printf   '    %s\n' ${cmd/:/: }
+        done
+    fi
 }
 
 zgenom-help $@

--- a/zgenom.zsh
+++ b/zgenom.zsh
@@ -26,3 +26,4 @@ function zgenom() {
 }
 
 alias zgen=zgenom
+typeset -a ZGENOM_EXTENSIONS


### PR DESCRIPTION
Extensions is far stretched. By design `zgenom` will work with every
function matching `zgenom-*`. This pr adds a safe way to call some
portions of the internal api and allows to add command descriptions to
help and completion using `$ZGENOM_EXTENSIONS`. Also defining
`_zgenom_*` will add completion for the subcommand well.