### PR TITLE
Fix Alias tip hinting to use zgen

### DIFF
--- a/zgenom.zsh
+++ b/zgenom.zsh
@@ -25,5 +25,5 @@ function zgenom() {
     esac
 }
 
-alias zgen=zgenom
+function zgen() zgenom $@
 typeset -a ZGENOM_EXTENSIONS


### PR DESCRIPTION
As seen in #72 Alias tip hints to use zgen instead of zgenom.