### PR TITLE
Allow adding just completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ if ! zgenom saved; then
     # plugins
     zgenom ohmyzsh plugins/git
     zgenom ohmyzsh plugins/sudo
+    # just load the completions
+    zgenom ohmyzsh plugins/docker-compose --completion
 
     # Install ohmyzsh osx plugin if on macOS
     [[ "$(uname -s)" = Darwin ]] && zgenom ohmyzsh plugins/osx
@@ -204,6 +206,8 @@ probably a better idea to always load the plugin instead.
 - Add `zgenom clean` to remove all unused plugins.
 - Add `zgenom autoupdate` to check for updates periodically and dispatch it to
   the background to remove any waiting times.
+- Allow just adding a plugins directory to fpath using `--completion` with
+  `load` or `ohmyzsh`.
 
 ## Usage
 
@@ -235,6 +239,9 @@ zgenom ohmyzsh
 zgenom ohmyzsh plugins/git
 zgenom ohmyzsh plugins/sudo
 zgenom ohmyzsh plugins/command-not-found
+# Just use the completions in this directory
+zgenom ohmyzsh plugins/docker-compose --completion
+
 zgenom ohmyzsh themes/arrow
 ```
 
@@ -311,11 +318,12 @@ information.](https://github.com/jandamm/zgenom/issues/48#issuecomment-763740949
 #### Load plugins and completions
 
 ```zsh
-zgenom load <repo> [location] [branch]
+zgenom load <repo> [location] [branch] [--completion]
 ```
 
 Zgenom tries to source any scripts from `location` using a "very smart matching
 logic". It will also append `location` to `$fpath`.
+If you add `--completion` it will only append `location` to `fpath`.
 
 - `repo`
   - github `user/repository` or path to a repository
@@ -331,6 +339,8 @@ logic". It will also append `location` to `$fpath`.
   - useful for repositories that don't have proper plugin
 - `branch`
   - specifies the git branch to use
+- `--completion`
+  - Don't source any file. Just add the given location to `$fpath`
 
 #### Load executables
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ if ! zgenom saved; then
     zgenom ohmyzsh plugins/git
     zgenom ohmyzsh plugins/sudo
     # just load the completions
-    zgenom ohmyzsh plugins/docker-compose --completion
+    zgenom ohmyzsh --completion plugins/docker-compose
 
     # Install ohmyzsh osx plugin if on macOS
     [[ "$(uname -s)" = Darwin ]] && zgenom ohmyzsh plugins/osx
@@ -240,7 +240,7 @@ zgenom ohmyzsh plugins/git
 zgenom ohmyzsh plugins/sudo
 zgenom ohmyzsh plugins/command-not-found
 # Just use the completions in this directory
-zgenom ohmyzsh plugins/docker-compose --completion
+zgenom ohmyzsh --completion plugins/docker-compose
 
 zgenom ohmyzsh themes/arrow
 ```

--- a/functions/_zgenom
+++ b/functions/_zgenom
@@ -65,6 +65,7 @@ function _zgenom() {
             case $subcmd in
                 compile) _files;;
                 selfupdate|update) _values -w options "--no-reset[don't remove init.zsh after updating]";;
+                load|ohmyzsh) _values -w options "--completion[only add this paths completions]";;
                 *) functions _zgenom_$subcmd &> /dev/null && _zgenom_$subcmd "$@";;
             esac
             ;;

--- a/functions/_zgenom
+++ b/functions/_zgenom
@@ -65,7 +65,7 @@ function _zgenom() {
             case $subcmd in
                 compile) _files;;
                 selfupdate|update) _values -w options "--no-reset[don't remove init.zsh after updating]";;
-                load|ohmyzsh) _values -w options "--completion[only add this paths completions]";;
+                load|ohmyzsh) _values -w options "--completion[only add to fpath]";;
                 *) functions _zgenom_$subcmd &> /dev/null && _zgenom_$subcmd "$@";;
             esac
             ;;

--- a/functions/zgenom-load
+++ b/functions/zgenom-load
@@ -32,6 +32,18 @@ function __zgenom_source() {
     fi
 }
 
+function __zgenom_completion() {
+    if [[ -d $location ]]; then
+        __zgenom_add_to_fpath $location
+    elif [[ -f $location && -d "${location:h}" ]]; then
+        __zgenom_add_to_fpath "${location:h}"
+    elif [[ -n $repo ]]; then
+        __zgenom_err "Failed to find '$file' in '$repo'. Couldn't add completion"
+    else
+        __zgenom_err "Failed to add completion for ${dir:-$location}"
+    fi
+}
+
 function __zgenom_add_to_fpath() {
     local completion_path="${1}"
 
@@ -43,10 +55,11 @@ function __zgenom_add_to_fpath() {
 }
 
 function zgenom-load() {
-    local location
+    local location completion
+    zparseopts -D -E -completion=completion || return
     if [[ "$#" == 0 ]]; then
         __zgenom_err '`load` requires at least one parameter:'
-        __zgenom_err '`zgenom load <repo> [location] [branch]`'
+        __zgenom_err '`zgenom load <repo> [location] [branch] [--location]`'
         return
     elif [[ "$#" == 1 && ("${1[1]}" == '/' || "${1[1]}" == '.' ) ]]; then
         location="${1}"
@@ -61,8 +74,16 @@ function zgenom-load() {
         zgenom-clone "${repo}" "${branch}"
     fi
 
+    # Don't source, just fpath
+    if [[ -n $completion ]]; then
+        __zgenom_completion
+        # Should bin be added?
+        # Not for now since the bins should probably be only added when the plugin is loaded.
+        # If only the bins should be added `zgenom bin <repo>` can be used instead.
+        return
+
     # source the file
-    if [[ -f "${location}" ]]; then
+    elif [[ -f "${location}" ]]; then
         __zgenom_source "${location}"
 
     # Prezto modules have init.zsh files

--- a/functions/zgenom-ohmyzsh
+++ b/functions/zgenom-ohmyzsh
@@ -1,12 +1,14 @@
 #!/usr/bin/env zsh
 
 function zgenom-oh-my-zsh() {
+    local completion
+    zparseopts -D -E -completion=completion || return
     if [[ -z $ZSH ]]; then
         ZSH="$(__zgenom_clone_dir $ZGEN_OH_MY_ZSH_REPO --branch $ZGEN_OH_MY_ZSH_BRANCH)"
     fi
 
     local file="${1:-oh-my-zsh.sh}"
-    zgenom-load "$ZGEN_OH_MY_ZSH_REPO" "${file}" "$ZGEN_OH_MY_ZSH_BRANCH"
+    zgenom-load "$ZGEN_OH_MY_ZSH_REPO" "${file}" "$ZGEN_OH_MY_ZSH_BRANCH" $completion
 }
 
 zgenom-oh-my-zsh $@


### PR DESCRIPTION
Instead of always sourcing all matching files in the given path.
`zgenom load --completion` or `zgenom ohmyzsh --completion` will do
this.

Closes #82