### PR TITLE
Refactor zgenom list to use --bin and --init

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ If you add `--completion` it will only append `location` to `fpath`.
 #### Load executables
 
 ```zsh
-zgenom load <repo> [location] [branch] [name]
+zgenom bin <repo> [location] [branch] [name]
 ```
 
 If `location` is omitted `./bin` is checked if `./bin` doesn't exist `.` is
@@ -354,7 +354,7 @@ checked. All executables in the found folder will be added to the path.
 If `location` is a folder all executables of this folder are added to the path.
 
 **Note:** This may lead to unwanted side-effects so it's recommended that you
-specify the files you need. You can use `zgenom list bin` to check which
+specify the files you need. You can use `zgenom list --bin` to check which
 executables are added.
 
 ```zsh

--- a/functions/_zgenom
+++ b/functions/_zgenom
@@ -64,6 +64,7 @@ function _zgenom() {
             local subcmd=$words[2]
             case $subcmd in
                 compile) _files;;
+                list) _values -w options '--bin[list bins]' '--init[show init file]';;
                 selfupdate|update) _values -w options "--no-reset[don't remove init.zsh after updating]";;
                 load|ohmyzsh) _values -w options "--completion[only add to fpath]";;
                 *) functions _zgenom_$subcmd &> /dev/null && _zgenom_$subcmd "$@";;

--- a/functions/zgenom-list
+++ b/functions/zgenom-list
@@ -1,13 +1,20 @@
 #!/usr/bin/env zsh
 
 function zgenom-list() {
-    if [[ $1 = 'bin' ]]; then
+    local bin init
+    zparseopts -D -E -bin=bin -init=init || return
+
+    if [[ -n $bin ]]; then
         ls $ZGENOM_SOURCE_BIN
-    elif [[ -f "${ZGEN_INIT}" ]]; then
-        cat "${ZGEN_INIT}"
-    else
-        __zgenom_err '`init.zsh` missing, please use `zgenom save` and then restart your shell.'
-        return 1
+    fi
+
+    if [[ -z $bin || -n $init ]]; then
+        if [[ -f "${ZGEN_INIT}" ]]; then
+            cat "${ZGEN_INIT}"
+        else
+            __zgenom_err '`init.zsh` missing, please use `zgenom save` and then restart your shell.'
+            return 1
+        fi
     fi
 }
 


### PR DESCRIPTION
Also fix an error in the readme showing `load` instead of `bin`.

Closes #88