### PR TITLE
Use absolute path for sourcing zshrc

### DIFF
--- a/functions/zgenom-autoupdate
+++ b/functions/zgenom-autoupdate
@@ -76,7 +76,7 @@ function zgenom-autoupdate() {
                 # Some plugins (e.g. romkatv/gitstatus) may raise issues with
                 # `zsh -il -c exit` since it isn't really an interactive shell.
                 # Hence a non interactive shell sourcing .zshrc is used.
-                local cmd="source ${${${(q)${ZDOTDIR:-~}}/#${(q)home}/'~'}//\%/%%}/.zshrc"
+                local cmd="echo ${${(q)${ZDOTDIR:-$HOME}}//\%/%%}/.zshrc"
                 local log=$(
                     __zgenom_autoupdate 2>&1 \
                         && printf 'Recreating init.zsh\n\n' \


### PR DESCRIPTION
Hopefully this fixes an issue with `~` expansion in some cases.
Closes #92