### PR TITLE
List zgenom-ext-eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,8 @@ Existing extensions:
 
 - [release](https://github.com/jandamm/zgenom-ext-release): Use `zgenom` and
   `gh` to download github releases.
+- [eval](https://github.com/jandamm/zgenom-ext-eval): Use `zgenom` to quickly
+  generate plugins from a command or heredoc.
 
 Please create a PR to add your extension here :)
 


### PR DESCRIPTION
This allows

```zsh
zgenom load zsh-users/zsh-history-substring-search
zgenom eval <<EOF
bindkey '^[[A' history-substring-search-up
bindkey '^[[B' history-substring-search-down
EOF

zgenom eval --name zoxide <<(zoxide init zsh)
```

Closes #84