### PR TITLE
Add zgenom compdef

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,9 +494,10 @@ zgenom compdef
 
 `compdef` is only available after `compinit` is called which zgenom executes
 after all plugins are loaded.  
-Some plugins might use compdef and either error or fail to add completions.
-Running `zgenom compdef` will wrap `compdef` and apply all calls after compinit
-was done.
+Some plugins might use `compdef` and either error or fail to add completions
+(if they check the existence of `compdef`).
+Running `zgenom compdef` will provide a `compdef` and apply all calls after
+compinit was done.
 
 #### Clean zgenom plugins
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ source "${HOME}/.zgenom/zgenom.zsh"
 # This does not increase the startup time.
 zgenom autoupdate
 
+# Add this if you experience issues with missing completions or errors mentioning compdef.
+# zgenom compdef
+
 # if the init script doesn't exist
 if ! zgenom saved; then
     echo "Creating a zgenom save"
@@ -482,6 +485,24 @@ plugins and machine.
 **Note:** If your .zshrc contains any interactive prompts you might encounter
 issues with some terminals. In this case you might want to try running the
 updates in sync using `--no-background`.
+
+#### Fix issues with compdef
+
+```zsh
+source "${HOME}/.zgenom/zgenom.zsh"
+
+zgenom compdef
+
+if ! zgenom saved; then
+  ...
+
+```
+
+`compdef` is only available after `compinit` is called which zgenom executes
+after all plugins are loaded.  
+Some plugins might use compdef and either error or fail to add completions.
+Running `zgenom compdef` will wrap `compdef` and apply all calls after compinit
+was done.
 
 #### Clean zgenom plugins
 

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ source "${HOME}/.zgenom/zgenom.zsh"
 # This does not increase the startup time.
 zgenom autoupdate
 
-# Add this if you experience issues with missing completions or errors mentioning compdef.
-# zgenom compdef
-
 # if the init script doesn't exist
 if ! zgenom saved; then
     echo "Creating a zgenom save"
+
+    # Add this if you experience issues with missing completions or errors mentioning compdef.
+    # zgenom compdef
 
     # Ohmyzsh base library
     zgenom ohmyzsh
@@ -489,13 +489,7 @@ updates in sync using `--no-background`.
 #### Fix issues with compdef
 
 ```zsh
-source "${HOME}/.zgenom/zgenom.zsh"
-
 zgenom compdef
-
-if ! zgenom saved; then
-  ...
-
 ```
 
 `compdef` is only available after `compinit` is called which zgenom executes

--- a/commands.txt
+++ b/commands.txt
@@ -4,6 +4,7 @@ autoupdate:^^^^automatically check for updates of zgenom and plugins
 bin:^^^^^^^^^^^clone and add files to PATH
 clean:^^^^^^^^^remove all unused repositories
 clone:^^^^^^^^^clone plugin from repository
+compdef:^^^^^^^add compdef and apply it after compinit
 compile:^^^^^^^compile files from the given path
 help:^^^^^^^^^^print usage information
 init:^^^^^^^^^^source the init.zsh

--- a/functions/zgenom-apply
+++ b/functions/zgenom-apply
@@ -8,7 +8,7 @@ function zgenom-apply() {
             eval "compinit $ZGEN_COMPINIT_FLAGS"
     fi
 
-    if [[ -n $_ZGENOM_COMPDEFS ]] __zgenom_compdef
+    if [[ -n $_ZGENOM_COMPDEF ]] __zgenom_compdef_apply
 
     if [[ ${ZGENOM_ADD_PATH} == 1 ]] && [[ -d $ZGENOM_SOURCE_BIN ]]; then
         path=($ZGENOM_SOURCE_BIN $path)

--- a/functions/zgenom-apply
+++ b/functions/zgenom-apply
@@ -8,6 +8,8 @@ function zgenom-apply() {
             eval "compinit $ZGEN_COMPINIT_FLAGS"
     fi
 
+    if [[ -n $_ZGENOM_COMPDEFS ]] __zgenom_compdef
+
     if [[ ${ZGENOM_ADD_PATH} == 1 ]] && [[ -d $ZGENOM_SOURCE_BIN ]]; then
         path=($ZGENOM_SOURCE_BIN $path)
     fi

--- a/functions/zgenom-compdef
+++ b/functions/zgenom-compdef
@@ -16,5 +16,7 @@ if ! typeset -f compdef &>/dev/null; then
     }
 fi
 
-# Ensure running once
-function zgenom-compdef() {}
+function zgenom-compdef() {
+    __zgenom_err 'Only call zgenom compdef once.'
+    return 1
+}

--- a/functions/zgenom-compdef
+++ b/functions/zgenom-compdef
@@ -1,18 +1,19 @@
 #!/usr/bin/env zsh
 
-if ! typeset -f compdef >/dev/null; then
+if ! typeset -f compdef &>/dev/null; then
+    _ZGENOM_COMPDEF=1
     _ZGENOM_COMPDEFS=()
+
     function compdef() {
         _ZGENOM_COMPDEFS+=("$*")
     }
 
-    function __zgenom_compdef() {
+    function __zgenom_compdef_apply() {
         local comp
         for comp in $_ZGENOM_COMPDEFS; do eval "compdef $comp"; done
-        unset _ZGENOM_COMPDEFS
+        unset _ZGENOM_COMPDEF _ZGENOM_COMPDEFS
+        unfunction __zgenom_compdef_apply
     }
-else
-    function __zgenom_compdef() {}
 fi
 
 # Ensure running once

--- a/functions/zgenom-compdef
+++ b/functions/zgenom-compdef
@@ -1,0 +1,19 @@
+#!/usr/bin/env zsh
+
+if ! typeset -f compdef >/dev/null; then
+    _ZGENOM_COMPDEFS=()
+    function compdef() {
+        _ZGENOM_COMPDEFS+=("$*")
+    }
+
+    function __zgenom_compdef() {
+        local comp
+        for comp in $_ZGENOM_COMPDEFS; do eval "compdef $comp"; done
+        unset _ZGENOM_COMPDEFS
+    }
+else
+    function __zgenom_compdef() {}
+fi
+
+# Ensure running once
+function zgenom-compdef() {}

--- a/functions/zgenom-save
+++ b/functions/zgenom-save
@@ -89,6 +89,9 @@ function zgenom-save() {
         __zgenom_write '   compinit -C '"${ZGEN_COMPINIT_DIR_FLAG}"
     fi
 
+    __zgenom_write
+    __zgenom_write 'if [[ -n $_ZGENOM_COMPDEFS ]] __zgenom_compdef'
+
     if [[ -d $ZGENOM_SOURCE_BIN ]]; then
         __zgenom_write
         __zgenom_write "# ### Bins"

--- a/functions/zgenom-save
+++ b/functions/zgenom-save
@@ -48,6 +48,12 @@ function zgenom-save() {
     __zgenom_write
     __zgenom_write "export PMSPEC=$PMSPEC"
     __zgenom_write "export ZPFX=${(q)ZPFX}"
+
+    if [[ -n $_ZGENOM_COMPDEF ]]; then
+        __zgenom_write
+        __zgenom_write 'autoload -Uz zgenom-compdef && zgenom-compdef'
+    fi
+
     __zgenom_write
     __zgenom_write "ZGENOM_PLUGINS=(${(@qOa)ZGENOM_PLUGINS})"
     if [[ -n $ZSH ]]; then
@@ -89,8 +95,10 @@ function zgenom-save() {
         __zgenom_write '   compinit -C '"${ZGEN_COMPINIT_DIR_FLAG}"
     fi
 
-    __zgenom_write
-    __zgenom_write 'if [[ -n $_ZGENOM_COMPDEFS ]] __zgenom_compdef'
+    if [[ -n $_ZGENOM_COMPDEF ]]; then
+        __zgenom_write
+        __zgenom_write '__zgenom_compdef_apply'
+    fi
 
     if [[ -d $ZGENOM_SOURCE_BIN ]]; then
         __zgenom_write

--- a/zgenom.zsh
+++ b/zgenom.zsh
@@ -15,11 +15,9 @@ fpath=($ZGEN_SOURCE/functions $fpath)
 autoload -Uz __zgenom
 autoload -Uz __zgenom_out
 autoload -Uz __zgenom_err
-autoload -Uz zgenom-compdef
 function zgenom() {
     case $1 in
     autoupdate) shift; autoload -Uz zgenom-autoupdate && zgenom-autoupdate $@;;
-    compdef) shift; zgenom-compdef $@;;
     init) zgenom saved || return 0;;
     # $ZGEN_INIT might delete itself when $ZGEN_RESET_ON_CHANGE is used.
     saved) [[ -f "${ZGEN_INIT}" ]] && source ${ZGEN_INIT} && [[ -f "${ZGEN_INIT}" ]];;

--- a/zgenom.zsh
+++ b/zgenom.zsh
@@ -15,9 +15,11 @@ fpath=($ZGEN_SOURCE/functions $fpath)
 autoload -Uz __zgenom
 autoload -Uz __zgenom_out
 autoload -Uz __zgenom_err
+autoload -Uz zgenom-compdef
 function zgenom() {
     case $1 in
     autoupdate) shift; autoload -Uz zgenom-autoupdate && zgenom-autoupdate $@;;
+    compdef) shift; zgenom-compdef $@;;
     init) zgenom saved || return 0;;
     # $ZGEN_INIT might delete itself when $ZGEN_RESET_ON_CHANGE is used.
     saved) [[ -f "${ZGEN_INIT}" ]] && source ${ZGEN_INIT} && [[ -f "${ZGEN_INIT}" ]];;


### PR DESCRIPTION
This solves the issue that some plugins use `compdef` but zgenom does
`compinit` after loading all plugins.