### PR TITLE
Fix localoptions being set for first zgenom call

### DIFF
--- a/functions/__zgenom
+++ b/functions/__zgenom
@@ -1,10 +1,12 @@
 #!/usr/bin/env zsh
 
 # Autoload all functions
-setopt localoptions extendedglob
-for func in $ZGEN_SOURCE/functions/(__|)zgenom(-|_)*~*.zwc; do
-    autoload -Uz ${func:t}
-done
+(){
+    setopt localoptions extendedglob
+    for func in $ZGEN_SOURCE/functions/(__|)zgenom(-|_)*~*.zwc; do
+        autoload -Uz ${func:t}
+    done
+}
 
 # Set all options
 source "$ZGEN_SOURCE/options.zsh"


### PR DESCRIPTION
When zgenom was fully loaded (`__zgenom`) localoptions and extendedglob
was being set to find all autoloaded functions.
This localoptions would prevent setting any options from the file
sourced by this first call.
So when for example the first call was `zgenom load my/plugin`
`my/plugin` wouldn't be able to set any options. This would only occur
in the first shell after `zgenom reset` since this issue would not
persist in the generated `init.zsh`.

Closes #101