### PR TITLE
Allow specifying options for zgenom compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,9 @@ zsh file it can recursively find in `~/.zsh`. You might not want to add any of
 these lines to your `.zsrhc` but run them manually or automatically in the
 background.
 
+You can provide the options `-UzkMR` to `zgenom compile`. They are just passed
+to `zcompile`. See `man zshbuiltins` for an explanation of the flags.
+
 #### Safely access internal api
 
 Calling any function matching `__zgenom-*` is assumed unsafe and the function

--- a/functions/_zgenom
+++ b/functions/_zgenom
@@ -59,6 +59,18 @@ function _zgenom_bin() {
     _values -w options $options
 }
 
+function _zgenom_compile() {
+    local options=(
+        '-M[mark as mapped]'
+        '-R[mark as read]'
+        "-U[don't expand aliases]"
+        '-k[ksh-style autoloading]'
+        '-z[zsh-style autoloading]'
+    )
+    _values -w options $options
+    _files
+}
+
 function _zgenom() {
     _arguments '1: :->cmd' '*: :->opts'
 
@@ -74,7 +86,6 @@ function _zgenom() {
         opts)
             local subcmd=$words[2]
             case $subcmd in
-                compile) _files;;
                 list) _values -w options '--bin[list bins]' '--init[show init file]';;
                 selfupdate|update) _values -w options "--no-reset[don't remove init.zsh after updating]";;
                 load|ohmyzsh) _values -w options "--completion[only add to fpath]";;

--- a/functions/zgenom-compile
+++ b/functions/zgenom-compile
@@ -1,21 +1,22 @@
 #!/usr/bin/env zsh
 
 function __zgenom_compile() {
-    local file=$1
-    if [ ! $file.zwc -nt $file ] && [[ -r $file ]]; then
-        zcompile -U $file
+    if [ $file -nt $file.zwc ] && [[ -r $file ]]; then
+        zcompile $opts $file
     fi
 }
 
 function zgenom-compile() {
-    local inp=$1
-    if [ -z $inp ]; then
+    local opts=()
+    zparseopts -a opts -D -- U k z R M || return
+    local file=$1
+    if [ -z $file ]; then
         __zgenom_err '`compile` requires one parameter:'
         __zgenom_err '`zgenom compile <location>`'
-    elif [ -f $inp ]; then
-        __zgenom_compile $inp
+    elif [ -f $file ]; then
+        __zgenom_compile
     else
-        for file in $inp/**/*(DN); do
+        for file in $file/**/*(DN); do
             # only files and ignore compiled files
             if [ ! -f $file ] || [[ $file = *.zwc ]]; then
                 continue
@@ -39,7 +40,7 @@ function zgenom-compile() {
                 fi
             fi
 
-            __zgenom_compile $file
+            __zgenom_compile
         done
     fi
 }

--- a/functions/zgenom-compile
+++ b/functions/zgenom-compile
@@ -8,7 +8,7 @@ function __zgenom_compile() {
 
 function zgenom-compile() {
     local opts=()
-    zparseopts -a opts -D -- U k z R M || return
+    zparseopts -a opts -D -- M R U k z || return
     local file=$1
     if [ -z $file ]; then
         __zgenom_err '`compile` requires one parameter:'

--- a/functions/zgenom-save
+++ b/functions/zgenom-save
@@ -111,21 +111,21 @@ function zgenom-save() {
     zgenom-apply
 
     __zgenom_err "Compiling files ..."
-    zgenom-compile $ZGEN_SOURCE
+    zgenom-compile -U $ZGEN_SOURCE
     if [[ $ZGEN_DIR != $ZGEN_SOURCE ]] && [[ $ZGEN_DIR != $ZGEN_SOURCE/* ]]; then
         # Compile ZGEN_DIR if not subdirectory of ZGEN_SOURCE
-        zgenom-compile $ZGEN_DIR
+        zgenom-compile -U $ZGEN_DIR
     fi
 
     if [[ -n $ZGEN_CUSTOM_COMPDUMP ]]; then
-        zgenom-compile $ZGEN_CUSTOM_COMPDUMP
+        zgenom-compile -U $ZGEN_CUSTOM_COMPDUMP
     else
         setopt localoptions nullglob
         for compdump in $HOME/.zcompdump*; do
             if [[ $compdump = *.zwc ]] || [[ ! -r $compdump ]]; then
                 continue
             fi
-            zgenom-compile $compdump
+            zgenom-compile -U $compdump
         done
     fi
 }


### PR DESCRIPTION
Those are the same options used by `zcompile`. These options are only
passed through.

Closes #102.