### PR TITLE
Allow compiling multiple paths with one call

### DIFF
--- a/functions/zgenom-compile
+++ b/functions/zgenom-compile
@@ -9,40 +9,45 @@ function __zgenom_compile() {
 function zgenom-compile() {
     local opts=()
     zparseopts -a opts -D -- M R U k z || return
-    local file=$1
-    if [ -z $file ]; then
+    if [[ $# -eq 0 ]]; then
         __zgenom_err '`compile` requires one parameter:'
         __zgenom_err '`zgenom compile <location>`'
-    elif [ -f $file ]; then
-        __zgenom_compile
-    else
-        for file in $file/**/*(DN); do
-            # only files and ignore compiled files
-            if [ ! -f $file ] || [[ $file = *.zwc ]]; then
-                continue
-
-            # Check *.sh if it can be parsed from zsh
-            elif [[ $file = *.sh ]]; then
-                if ! zsh -n $file 2>/dev/null; then
-                    continue
-                fi
-
-            # Check for shebang if not:
-            # - zsh startup file
-            # - *.zsh
-            # - zcompdump*
-            elif [[ $file != *.zsh ]] \
-                && [[ $file != *zcompdump* ]] \
-                && [[ ! $file =~ '\.z(shenv|profile|shrc|login|logout)$' ]]; then
-                read -r firstline < $file
-                if [[ ! $firstline =~ '^#!.*zsh' ]] 2>/dev/null; then
-                    continue
-                fi
-            fi
-
-            __zgenom_compile
-        done
     fi
+
+    local file
+    while [[ $# -gt 0 ]]; do
+        file=$1; shift
+        if [ -f $file ]; then
+            __zgenom_compile
+        else
+            for file in $file/**/*(DN); do
+                # only files and ignore compiled files
+                if [ ! -f $file ] || [[ $file = *.zwc ]]; then
+                    continue
+
+                # Check *.sh if it can be parsed from zsh
+                elif [[ $file = *.sh ]]; then
+                    if ! zsh -n $file 2>/dev/null; then
+                        continue
+                    fi
+
+                # Check for shebang if not:
+                # - zsh startup file
+                # - *.zsh
+                # - zcompdump*
+                elif [[ $file != *.zsh ]] \
+                    && [[ $file != *zcompdump* ]] \
+                    && [[ ! $file =~ '\.z(shenv|profile|shrc|login|logout)$' ]]; then
+                    read -r firstline < $file
+                    if [[ ! $firstline =~ '^#!.*zsh' ]] 2>/dev/null; then
+                        continue
+                    fi
+                fi
+
+                __zgenom_compile
+            done
+        fi
+    done
 }
 
 zgenom-compile $@


### PR DESCRIPTION
While I don't think this is needed it is easier to allow compiling
multiple files with one statement than preventing completion from only
completing exactly one file/path.