### PR TITLE
Fix not compiling files when no zwc exists

### DIFF
--- a/functions/zgenom-compile
+++ b/functions/zgenom-compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 function __zgenom_compile() {
-    if [ $file -nt $file.zwc ] && [[ -r $file ]]; then
+    if [[ ! -f $file.zwc || $file -nt $file.zwc ]] && [[ -r $file ]]; then
         zcompile $opts $file
     fi
 }


### PR DESCRIPTION
This issue was introduced in #106.