### PR TITLE
Fix bug where loading and migrating plugins with spaces in them fails

### DIFF
--- a/functions/zgenom-clone
+++ b/functions/zgenom-clone
@@ -25,7 +25,7 @@ function __zgenom_migrate_dir() {
     local dir="${1}"
     local repo="${2}"
     local branch="${3}"
-    command mkdir -p ${dir:h} && command mv $(__zgenom_clone_dir ${repo} --branch ${branch} --legacy) $dir
+    command mkdir -p ${dir:h} && command mv "$(__zgenom_clone_dir ${repo} --branch ${branch} --legacy)" $dir
 }
 
 function zgenom-clone() {

--- a/functions/zgenom-save
+++ b/functions/zgenom-save
@@ -47,12 +47,12 @@ function zgenom-save() {
 
     __zgenom_write
     __zgenom_write "export PMSPEC=$PMSPEC"
-    __zgenom_write "export ZPFX=$ZPFX"
+	__zgenom_write "export ZPFX=${(q)ZPFX}"
     __zgenom_write
     __zgenom_write "ZGENOM_PLUGINS=(${(@qOa)ZGENOM_PLUGINS})"
     if [[ -n $ZSH ]]; then
         __zgenom_write
-        __zgenom_write "ZSH=$ZSH"
+		__zgenom_write "ZSH=${(q)ZSH}"
     fi
     if [[ ${ZGEN_USE_PREZTO} == 1 && $#ZGEN_PREZTO_OPTIONS -gt 0 ]]; then
         __zgenom_write

--- a/functions/zgenom-save
+++ b/functions/zgenom-save
@@ -47,12 +47,12 @@ function zgenom-save() {
 
     __zgenom_write
     __zgenom_write "export PMSPEC=$PMSPEC"
-	__zgenom_write "export ZPFX=${(q)ZPFX}"
+    __zgenom_write "export ZPFX=${(q)ZPFX}"
     __zgenom_write
     __zgenom_write "ZGENOM_PLUGINS=(${(@qOa)ZGENOM_PLUGINS})"
     if [[ -n $ZSH ]]; then
         __zgenom_write
-		__zgenom_write "ZSH=${(q)ZSH}"
+        __zgenom_write "ZSH=${(q)ZSH}"
     fi
     if [[ ${ZGEN_USE_PREZTO} == 1 && $#ZGEN_PREZTO_OPTIONS -gt 0 ]]; then
         __zgenom_write


### PR DESCRIPTION
Thanks for reviving zgen and adding new features!

I tried migrating from zgen to zgenom and had a few hiccups due to the fact that zgenom does not take into account spaces in file paths when migrating or loading plugins. I'm on macOS and try to keep things organized into directories according to how macOS stores configuration files for programs (e.g. `~/Library/Application Support`) so that my home directory is not cluttered with hidden files and directories specific to each program. Because of this I've set `$ZGEN_DIR` to `~/Library/Application Support/net.sourceforge.Zsh/zgen` (`net.sourceforge.Zsh` is supposed to mimic how other applications name their configuration directories, for example there is also `com.microsoft.OneDrive` and `com.apple.spotlight`). The space in `Application Support` can sometimes break things that don't escape that space and cause Zsh to do word splitting, and so zgenom didn't work for me at first until I made the changes in this PR.

After adding the few changes I've made here, zgenom started working for me, but I'm not sure if there were other places where the space escaping could be added that I just never encountered.