### PR TITLE
Breaking: Move zgen compatibility into `zgen.zsh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ zgen reset
 When you start a new shell your plugins will be migrated. You don't have to
 change your `.zshrc`.
 
+**Note:** `zgen` is only present if you source `zgen.zsh`.
+
 The preferred way would be to just delete zgen and start fresh.
 
 **Note:** If you keep `~/.zgen` around, zgenom will use it to store the plugins

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -1,1 +1,3 @@
-zgenom.zsh
+cat "$0:A:h/zgenom.zsh"
+
+function zgen() zgenom $@

--- a/zgenom.zsh
+++ b/zgenom.zsh
@@ -25,5 +25,4 @@ function zgenom() {
     esac
 }
 
-function zgen() zgenom $@
 typeset -a ZGENOM_EXTENSIONS


### PR DESCRIPTION
If you currently use `zgen` instead of `zgenom` you now have to source
`zgen.zsh` instead of `zgenom.zsh`.