### PR TITLE
Don't compile files in .git folders

### DIFF
--- a/functions/zgenom-compile
+++ b/functions/zgenom-compile
@@ -20,13 +20,10 @@ function zgenom-compile() {
         if [ -f $file ]; then
             __zgenom_compile
         else
-            for file in $file/**/*(DN); do
-                # only files and ignore compiled files
-                if [ ! -f $file ] || [[ $file = *.zwc ]]; then
-                    continue
-
+            # only files, ignore compiled files and ignore .git folders
+            for file in $file/**/*~*/.git/*~*.zwc(.DN); do
                 # Check *.sh if it can be parsed from zsh
-                elif [[ $file = *.sh ]]; then
+                if [[ $file = *.sh ]]; then
                     if ! zsh -n $file 2>/dev/null; then
                         continue
                     fi


### PR DESCRIPTION
Also move `if` logic to the glob itself.
~*.zwc -> only when it does not match *.zwc
(.)    -> only match files