### PR TITLE
fix sourcing plugins

### DIFF
--- a/functions/zgenom-load
+++ b/functions/zgenom-load
@@ -28,7 +28,7 @@ function __zgenom_source() {
         fi
 
         zsh_loaded_plugins+=( "$repo_id" )
-        ZERO="${source_file}" source "${source_file}"
+        set -- && ZERO="${source_file}" source "${source_file}"
     fi
 }
 

--- a/functions/zgenom-save
+++ b/functions/zgenom-save
@@ -85,7 +85,7 @@ function zgenom-save() {
         for i in {1.."${#ZGEN_LOADED}"}; do
             file="${ZGEN_LOADED[$i]}"
             __zgenom_write "zsh_loaded_plugins+=( ${(qqq)ZGENOM_LOADED[$i]} )"
-            __zgenom_write "ZERO=${(qqq)file} source ${(qqq)file}"
+            __zgenom_write "set -- && ZERO=${(qqq)file} source ${(qqq)file}"
         done
     fi
 


### PR DESCRIPTION
fix the bug mentioned in romkatv/gitstatus#168.

we'll get the error something like
```
blahblah...: not valid in this context: _gitstatus_plugin_dir/Users/javenwang/.zgenom/sources/romkatv/gitstatus-master/gitstatus.plugin.zsh
```
when `zgenom load romkatv/gitstatus` in `.zshrc`.