### PR TITLE
Exclude test dirs and specific file extensions from zsh compilation (#156)

### DIFF
--- a/functions/zgenom-compile
+++ b/functions/zgenom-compile
@@ -20,8 +20,25 @@ function zgenom-compile() {
         if [ -f $file ]; then
             __zgenom_compile
         else
-            # only files, ignore compiled files and ignore .git folders
-            for file in $file/**/*~*/.git/*~*.zwc(.DN); do
+            # Build pattern for files that require compilation
+            local pattern="$file/**/*"
+
+            # Exclude any dirs (recursively) in this list
+            local exclude_dirs=(.git spec test tests)
+            for dir in $exclude_dirs; do
+              pattern+="~*/$dir/*~*/$dir/**/*"
+            done
+
+            # Include only files, ignore some files by extension
+            local exclude_exts=(db gif json md png rb py xml yml yaml zwc)
+            for ext in $exclude_exts; do
+              pattern+="~*.${ext}"
+            done
+
+            # glob qualifier to match only regular files, include dotfiles, and allow nullglob
+            pattern+='(.DN)'
+
+            for file in ${~pattern}; do
                 # Check *.sh if it can be parsed from zsh
                 if [[ $file = *.sh ]]; then
                     if ! zsh -n $file 2>/dev/null; then


### PR DESCRIPTION
Fixes issue #156

This also fixes an issue with the existing glob pattern, it turns out that it was still iterating over all the files in '.git' directories.  I won't take any credit here (except for noticing it in the logging), ChatGPT explained everything and helped me write the proper code.

I generalized the directory exclusions so there is a list of directories that are recursively excluded.  I also generalized the file extension exclusion from only `zwc` to exclude a bunch of obviously non-zsh files (as well as zwc files).  Although reading the first line doesn't take a ton of time, it's still not as fast as skipping the files entirely.  The net result is a substantial reduction in the time it takes to run the compile phase.  Here are numbers:

tl;dr:  Time to run `zgenom-compile` was reduced from `6616.89` to `962.19`, which is a 6.88x speedup (~85% reduction in time spent compiling).

zprof results:

On main branch:
```
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    3        6616.89  2205.63   82.33%   6583.44  2194.48   81.91%  zgenom-compile
 2)    1         402.72   402.72    5.01%    402.72   402.72    5.01%  compdump
 3)  980         277.59     0.28    3.45%    277.59     0.28    3.45%  compdef
 4)    2        1008.01   504.01   12.54%    254.31   127.16    3.16%  compinit
 5)    2          73.46    36.73    0.91%     73.46    36.73    0.91%  compaudit
 6)   20         173.44     8.67    2.16%     67.03     3.35    0.83%  __zgenom_source
 7)   22          55.69     2.53    0.69%     55.69     2.53    0.69%  zgenom-clone
 8)   22         287.62    13.07    3.58%     49.49     2.25    0.62%  zgenom-load
 9)    1          41.82    41.82    0.52%     41.82    41.82    0.52%  _zsh_highlight_bind_widgets
10) 1004          33.45     0.03    0.42%     33.45     0.03    0.42%  __zgenom_compile
11)    9          65.99     7.33    0.82%     30.20     3.36    0.38%  pmodload
12)    1          27.33    27.33    0.34%     27.33    27.33    0.34%  rad_git_plugin_init_hook
13)    1          33.13    33.13    0.41%     23.07    23.07    0.29%  sdkman-init
14)    2        7631.05  3815.52   94.95%     14.45     7.22    0.18%  zgenom-save
```

On this branch:
```
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    3         962.19   320.73   38.94%    928.22   309.41   37.56%  zgenom-compile
 2)    1         407.33   407.33   16.48%    407.33   407.33   16.48%  compdump
 3)    2        1080.62   540.31   43.73%    300.34   150.17   12.15%  compinit
 4)  980         294.00     0.30   11.90%    294.00     0.30   11.90%  compdef
 5)    2          79.02    39.51    3.20%     79.02    39.51    3.20%  compaudit
 6)   20         184.11     9.21    7.45%     73.13     3.66    2.96%  __zgenom_source
 7)   22          56.21     2.56    2.27%     56.21     2.56    2.27%  zgenom-clone
 8)   22         295.82    13.45   11.97%     47.00     2.14    1.90%  zgenom-load
 9)    1          45.44    45.44    1.84%     45.44    45.44    1.84%  _zsh_highlight_bind_widgets
10)  990          33.94     0.03    1.37%     33.94     0.03    1.37%  __zgenom_compile
11)    9          70.58     7.84    2.86%     32.58     3.62    1.32%  pmodload
12)    1          26.70    26.70    1.08%     26.70    26.70    1.08%  rad_git_plugin_init_hook
13)    1          34.42    34.42    1.39%     24.96    24.96    1.01%  sdkman-init
14)    2        2050.74  1025.37   82.99%     16.63     8.32    0.67%  zgenom-save
```

Note: I had to build the pattern iteratively as I could not find any way to make zsh array expansion generate the correct pattern.  It also seems to be a strong requirement to add the directories twice (once for direct children, once for the recursive exclusion).  I thoroughly explored all options related to those two things, and while I may have missed something, it's not anything obvious or standard.